### PR TITLE
Change the repo from which ts_proto_library is loaded.

### DIFF
--- a/proto/logger/BUILD
+++ b/proto/logger/BUILD
@@ -2,4 +2,4 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-# load("@build_bazel_rules_typescript//:defs.bzl", "ts_proto_library")
+# load("@npm_bazel_typescript//:index.bzl", "ts_proto_library")


### PR DESCRIPTION
Having done the codelab, the new source seems to work while the old one doesn't.
Otherwsie, I don't really know enough about typescript to know if this change makes sense.