### PR TITLE
Update external repos to fix the build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,18 +1,16 @@
 workspace(name = "bootcamp")
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # grpc dependencies
-git_repository(
+http_archive(
     name = "io_grpc_grpc_java",
     # TODO: Update reference to a release version (once it exists) that contains
-    # a4299eb6bed3c2f2497f583d0c4620c9f31ec455. Maybe use a http_archive instead of git_repository
-    # if http_archive is better in some way.
+    # a4299eb6bed3c2f2497f583d0c4620c9f31ec455.
     # Commit a4299eb6bed3c2f2497f583d0c4620c9f31ec455 fixed
     # https://github.com/grpc/grpc-java/issues/6536. That bug caused test failures on Bazel CI.
-    commit = "a4299eb6bed3c2f2497f583d0c4620c9f31ec455",
-    remote = "https://github.com/grpc/grpc-java",
+    urls = ["https://github.com/grpc/grpc-java/archive/a4299eb6bed3c2f2497f583d0c4620c9f31ec455.tar.gz"],
+    strip_prefix = "grpc-java-a4299eb6bed3c2f2497f583d0c4620c9f31ec455",
 )
 
 load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,11 +26,11 @@ protobuf_deps()
 # go dependencies
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "8df59f11fb697743cbb3f26cfb8750395f30471e9eabde0d174c3aebc7a1cd39",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.19.1/rules_go-0.19.1.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.19.1/rules_go-0.19.1.tar.gz",
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.21.0/rules_go-v0.21.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.21.0/rules_go-v0.21.0.tar.gz",
     ],
+    sha256 = "b27e55d2dcc9e6020e17614ae6e0374818a3e3ce6f2024036e688ada24110444",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,6 +19,10 @@ load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
 
 grpc_java_repositories()
 
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
 # go dependencies
 http_archive(
     name = "io_bazel_rules_go",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,15 +1,18 @@
 workspace(name = "bootcamp")
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # grpc dependencies
-http_archive(
+git_repository(
     name = "io_grpc_grpc_java",
-    sha256 = "6e63bd6f5a82de0b84c802390adb8661013bad9ebf910ad7e1f3f72b5f798832",
-    strip_prefix = "grpc-java-1.22.1",
-    urls = [
-        "https://github.com/grpc/grpc-java/archive/v1.22.1.tar.gz",
-    ],
+    # TODO: Update reference to a release version (once it exists) that contains
+    # a4299eb6bed3c2f2497f583d0c4620c9f31ec455. Maybe use a http_archive instead of git_repository
+    # if http_archive is better in some way.
+    # Commit a4299eb6bed3c2f2497f583d0c4620c9f31ec455 fixed
+    # https://github.com/grpc/grpc-java/issues/6536. That bug caused test failures on Bazel CI.
+    commit = "a4299eb6bed3c2f2497f583d0c4620c9f31ec455",
+    remote = "https://github.com/grpc/grpc-java",
 )
 
 load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,6 +9,8 @@ http_archive(
     # a4299eb6bed3c2f2497f583d0c4620c9f31ec455.
     # Commit a4299eb6bed3c2f2497f583d0c4620c9f31ec455 fixed
     # https://github.com/grpc/grpc-java/issues/6536. That bug caused test failures on Bazel CI.
+    # We don't specify sha256, because the sha256 of GitHub-served non-release archives isn't
+    # stable.
     urls = ["https://github.com/grpc/grpc-java/archive/a4299eb6bed3c2f2497f583d0c4620c9f31ec455.tar.gz"],
     strip_prefix = "grpc-java-a4299eb6bed3c2f2497f583d0c4620c9f31ec455",
 )

--- a/generate_workspace.sh
+++ b/generate_workspace.sh
@@ -6,19 +6,17 @@
 # write WORKSPACE file
 cat > WORKSPACE <<EOF
 workspace(name = "bootcamp")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # grpc dependencies
-git_repository(
+http_archive(
     name = "io_grpc_grpc_java",
     # TODO: Update reference to a release version (once it exists) that contains
-    # a4299eb6bed3c2f2497f583d0c4620c9f31ec455. Maybe use a http_archive instead of git_repository
-    # if http_archive is better in some way.
+    # a4299eb6bed3c2f2497f583d0c4620c9f31ec455.
     # Commit a4299eb6bed3c2f2497f583d0c4620c9f31ec455 fixed
     # https://github.com/grpc/grpc-java/issues/6536. That bug caused test failures on Bazel CI.
-    commit = "a4299eb6bed3c2f2497f583d0c4620c9f31ec455",
-    remote = "https://github.com/grpc/grpc-java",
+    urls = ["https://github.com/grpc/grpc-java/archive/a4299eb6bed3c2f2497f583d0c4620c9f31ec455.tar.gz"],
+    strip_prefix = "grpc-java-a4299eb6bed3c2f2497f583d0c4620c9f31ec455",
 )
 
 load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")

--- a/generate_workspace.sh
+++ b/generate_workspace.sh
@@ -20,7 +20,9 @@ git_repository(
     commit = "a4299eb6bed3c2f2497f583d0c4620c9f31ec455",
     remote = "https://github.com/grpc/grpc-java",
 )
+
 load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
+
 grpc_java_repositories()
 
 

--- a/generate_workspace.sh
+++ b/generate_workspace.sh
@@ -10,13 +10,15 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # grpc dependencies
-http_archive(
+git_repository(
     name = "io_grpc_grpc_java",
-    urls = [
-        "https://github.com/grpc/grpc-java/archive/v1.22.1.tar.gz",
-    ],
-    sha256 = "6e63bd6f5a82de0b84c802390adb8661013bad9ebf910ad7e1f3f72b5f798832",
-    strip_prefix = "grpc-java-1.22.1",
+    # TODO: Update reference to a release version (once it exists) that contains
+    # a4299eb6bed3c2f2497f583d0c4620c9f31ec455. Maybe use a http_archive instead of git_repository
+    # if http_archive is better in some way.
+    # Commit a4299eb6bed3c2f2497f583d0c4620c9f31ec455 fixed
+    # https://github.com/grpc/grpc-java/issues/6536. That bug caused test failures on Bazel CI.
+    commit = "a4299eb6bed3c2f2497f583d0c4620c9f31ec455",
+    remote = "https://github.com/grpc/grpc-java",
 )
 load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
 grpc_java_repositories()

--- a/generate_workspace.sh
+++ b/generate_workspace.sh
@@ -15,6 +15,8 @@ http_archive(
     # a4299eb6bed3c2f2497f583d0c4620c9f31ec455.
     # Commit a4299eb6bed3c2f2497f583d0c4620c9f31ec455 fixed
     # https://github.com/grpc/grpc-java/issues/6536. That bug caused test failures on Bazel CI.
+    # We don't specify sha256, because the sha256 of GitHub-served non-release archives isn't
+    # stable.
     urls = ["https://github.com/grpc/grpc-java/archive/a4299eb6bed3c2f2497f583d0c4620c9f31ec455.tar.gz"],
     strip_prefix = "grpc-java-a4299eb6bed3c2f2497f583d0c4620c9f31ec455",
 )

--- a/generate_workspace.sh
+++ b/generate_workspace.sh
@@ -34,12 +34,14 @@ protobuf_deps()
 http_archive(
     name = "io_bazel_rules_go",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.19.1/rules_go-0.19.1.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.19.1/rules_go-0.19.1.tar.gz",
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.21.0/rules_go-v0.21.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.21.0/rules_go-v0.21.0.tar.gz",
     ],
-    sha256 = "8df59f11fb697743cbb3f26cfb8750395f30471e9eabde0d174c3aebc7a1cd39",
+    sha256 = "b27e55d2dcc9e6020e17614ae6e0374818a3e3ce6f2024036e688ada24110444",
 )
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
 go_rules_dependencies()
 go_register_toolchains()
 

--- a/generate_workspace.sh
+++ b/generate_workspace.sh
@@ -25,6 +25,10 @@ load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
 
 grpc_java_repositories()
 
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
 
 # go dependencies
 http_archive(


### PR DESCRIPTION
Updade `io_grpc_grpc_java`, `protobuf_deps`, and `rules_go` to newer versions.
This shall fix the build of `//...` with Bazel 2.0.0 on Linux.

Fixes https://github.com/bazelbuild/codelabs/issues/29