### PR TITLE
Upgrade rules_nodjes and rules_typescript

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,13 +102,11 @@ go_repository(
 # BEGIN: Typescript dependencies
 # http_archive(
 #     name = "build_bazel_rules_nodejs",
-#     urls = [
-#         "https://github.com/bazelbuild/rules_nodejs/releases/download/0.35.0/rules_nodejs-0.35.0.tar.gz",
-#     ],
-#     sha256 = "6625259f9f77ef90d795d20df1d0385d9b3ce63b6619325f702b6358abb4ab33",
+#     sha256 = "84abf7ac4234a70924628baa9a73a5a5cbad944c4358cf9abdb4aab29c9a5b77",
+#     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.7.0/rules_nodejs-1.7.0.tar.gz"],
 # )
 
-# load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
+# load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
 
 # yarn_install(
 #     name = "npm",

--- a/generate_workspace.sh
+++ b/generate_workspace.sh
@@ -109,13 +109,11 @@ go_repository(
 # BEGIN: Typescript dependencies
 http_archive(
     name = "build_bazel_rules_nodejs",
-    urls = [
-        "https://github.com/bazelbuild/rules_nodejs/releases/download/0.35.0/rules_nodejs-0.35.0.tar.gz",
-    ],
-    sha256 = "6625259f9f77ef90d795d20df1d0385d9b3ce63b6619325f702b6358abb4ab33",
+    sha256 = "84abf7ac4234a70924628baa9a73a5a5cbad944c4358cf9abdb4aab29c9a5b77",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.7.0/rules_nodejs-1.7.0.tar.gz"],
 )
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
 
 yarn_install(
     name = "npm",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "devDependencies": {
     "@bazel/hide-bazel-files": "latest",
-    "@bazel/typescript": "^0.35.0",
+    "@bazel/typescript": "^1.7.0",
     "protobufjs": "5.0.3",
     "typescript": "^3.3.1"
   }


### PR DESCRIPTION
rules_nodejs pre 1.6.0 had invalid escape sequences in its Starlark code, which was silently ignored but now throws an error (due to bazelbuild/bazel@73402fa).